### PR TITLE
CHANGED: Update deprecated ingress resources (Section 25, Lesson 99)

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: cheddar
@@ -8,11 +8,14 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: cheddar
-          servicePort: 80
+          service:
+            name: cheddar
+            port:
+              number: 80
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: stilton
@@ -22,11 +25,14 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: stilton
-          servicePort: 80
+          service:
+            name: stilton
+            port:
+              number: 80
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wensleydale
@@ -36,7 +42,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: wensleydale
-          servicePort: 80
+          service:
+            name: wensleydale
+            port:
+              number: 80
 ---

--- a/k8s/redirect.yaml
+++ b/k8s/redirect.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-google
@@ -9,6 +9,9 @@ spec:
   - http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: doesntmatter
-          servicePort: 80
+          service:
+            name: doesntmatter
+            port:
+              number: 80


### PR DESCRIPTION
In relation to: Section 25, Lesson 99

Changing the ingress.yaml should remove the deprecation errors caused by using a k8s v1.14+

When creating the ingresses resources: `kubectl apply -f ingress.yaml`

![Screen Shot 2021-03-24 at 6 51 46 PM](https://user-images.githubusercontent.com/5805/112402779-bf927780-8cd2-11eb-803e-663cb3ad6fa4.png)


When listing the ingress resources: `kubectl get ingress`

![Screen Shot 2021-03-24 at 6 54 04 PM](https://user-images.githubusercontent.com/5805/112402785-c28d6800-8cd2-11eb-8a2a-9bd2cc0848d3.png)
