### PR TITLE
applying changes from officially recommended dashboard 2.5.0

### DIFF
--- a/k8s/insecure-dashboard.yaml
+++ b/k8s/insecure-dashboard.yaml
@@ -185,9 +185,12 @@ spec:
       labels:
         k8s-app: kubernetes-dashboard
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: kubernetes-dashboard
-          image: kubernetesui/dashboard:v2.0.0
+          image: kubernetesui/dashboard:v2.5.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8443
@@ -226,7 +229,7 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -267,12 +270,13 @@ spec:
     metadata:
       labels:
         k8s-app: dashboard-metrics-scraper
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: dashboard-metrics-scraper
-          image: kubernetesui/metrics-scraper:v1.0.4
+          image: kubernetesui/metrics-scraper:v1.0.7
           ports:
             - containerPort: 8000
               protocol: TCP
@@ -293,7 +297,7 @@ spec:
             runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master


### PR DESCRIPTION
Hi Bret,
i am currently taking your k8s udemy course, and i had some problems when trying to use the insecure dashboard on a current kubernetes version. So i took the changes from the current kubernetes dashboard (2.5.0/recommended.yaml) and applied them to this file. Maybe it helps some of your newer students to get things up running more easily.
BR 
René


