### PR TITLE
Fixing ingressClass for swapping ingress controllers

### DIFF
--- a/k8s/ic-nginx-hn.yaml
+++ b/k8s/ic-nginx-hn.yaml
@@ -310,6 +310,7 @@ spec:
             - --election-id=ingress-controller-leader
             - --controller-class=k8s.io/ingress-nginx
             - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+            - --watch-ingress-without-class=true
           securityContext:
             capabilities:
               drop:
@@ -365,22 +366,12 @@ spec:
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 300
 ---
-# Source: ingress-nginx/templates/controller-ingressclass.yaml
-# We don't support namespaced ingressClass yet
-# So a ClusterRole and a ClusterRoleBinding is required
+# more info https://github.com/kubernetes/ingress-nginx/blob/main/docs/index.md#i-have-only-one-ingress-controller-in-my-cluster-what-should-i-do
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
-  labels:
-    helm.sh/chart: ingress-nginx-4.0.10
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: 1.1.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: controller
-  name: nginx
-  namespace: ingress-nginx
+  name: cluster-wide-ingress
 spec:
   controller: k8s.io/ingress-nginx

--- a/k8s/ic-nginx-lb.yaml
+++ b/k8s/ic-nginx-lb.yaml
@@ -310,6 +310,7 @@ spec:
             - --election-id=ingress-controller-leader
             - --controller-class=k8s.io/ingress-nginx
             - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+            - --watch-ingress-without-class=true
           securityContext:
             capabilities:
               drop:
@@ -365,22 +366,12 @@ spec:
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 300
 ---
-# Source: ingress-nginx/templates/controller-ingressclass.yaml
-# We don't support namespaced ingressClass yet
-# So a ClusterRole and a ClusterRoleBinding is required
+# more info https://github.com/kubernetes/ingress-nginx/blob/main/docs/index.md#i-have-only-one-ingress-controller-in-my-cluster-what-should-i-do
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
-  labels:
-    helm.sh/chart: ingress-nginx-4.0.10
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: 1.1.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: controller
-  name: nginx
-  namespace: ingress-nginx
+  name: cluster-wide-ingress
 spec:
   controller: k8s.io/ingress-nginx

--- a/k8s/ic-traefik-hn.yaml
+++ b/k8s/ic-traefik-hn.yaml
@@ -16,7 +16,6 @@ spec:
   selector:
     matchLabels:
       k8s-app: traefik-ingress-lb
-      name: traefik-ingress-lb
   template:
     metadata:
       labels:
@@ -26,19 +25,19 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
+      hostNetwork: true
       serviceAccountName: traefik-ingress-controller
       terminationGracePeriodSeconds: 60
-      hostNetwork: true
       containers:
-      - image: traefik:2.5
+      - image: traefik:v2.7
         name: traefik-ingress-lb
         ports:
         - name: http
           containerPort: 80
           hostPort: 80
-        # - name: admin
-          # containerPort: 8080
-          # hostPort: 8080
+        - name: admin
+          containerPort: 8080
+          hostPort: 8080
         securityContext:
           capabilities:
             drop:
@@ -46,35 +45,21 @@ spec:
             add:
             - NET_BIND_SERVICE
         args:
-        - --providers.kubernetesingress=true
+        ## the web UI on the host NIC port 8080 in **insecure** mode
+        - --api.dashboard
+        - --accesslog
+        - --api
+        - --api.insecure
+        - --log.level=INFO
+        - --metrics.prometheus
+        - --providers.kubernetesingress
+        - --providers.kubernetesingress.ingressclass=cluster-wide-ingress
+        - --entrypoints.http.Address=:80
         # you need to manually set this IP to the incoming public IP
         # that your ingress resources would use. Note it only affects
         # status and kubectl UI, and doesn't really do anything
         # It could even be left out https://github.com/containous/traefik/issues/6303
-        - --providers.kubernetesingress.ingressendpoint.ip=127.0.0.1
-        ## uncomment these and the ports above and below to enable
-        ## the web UI on the host NIC port 8080 in **insecure** mode
-        # - --api.dashboard=true
-        # - --api.insecure=true
-        - --log=true
-        - --log.level=INFO
-        - --accesslog=true
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: traefik-ingress-service
-  namespace: kube-system
-spec:
-  selector:
-    k8s-app: traefik-ingress-lb
-  ports:
-    - protocol: TCP
-      port: 80
-      name: web
-    # - protocol: TCP
-      # port: 8080
-      # name: admin
+        - --providers.kubernetesingress.ingressendpoint.hostname=localhost
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -93,8 +78,33 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - ingressroutes
+      - ingressroutetcps
+      - ingressrouteudps
+      - middlewares
+      - middlewaretcps
+      - tlsoptions
+      - tlsstores
+      - traefikservices
+      - serverstransports
     verbs:
       - get
       - list
@@ -112,3 +122,12 @@ subjects:
 - kind: ServiceAccount
   name: traefik-ingress-controller
   namespace: kube-system
+---
+kind: IngressClass
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cluster-wide-ingress
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: traefik.io/ingress-controller

--- a/k8s/ic-traefik-lb.yaml
+++ b/k8s/ic-traefik-lb.yaml
@@ -16,7 +16,6 @@ spec:
   selector:
     matchLabels:
       k8s-app: traefik-ingress-lb
-      name: traefik-ingress-lb
   template:
     metadata:
       labels:
@@ -29,7 +28,7 @@ spec:
       serviceAccountName: traefik-ingress-controller
       terminationGracePeriodSeconds: 60
       containers:
-      - image: traefik:2.5
+      - image: traefik:2.7
         name: traefik-ingress-lb
         ports:
         - name: http
@@ -43,19 +42,21 @@ spec:
             add:
             - NET_BIND_SERVICE
         args:
-        - --providers.kubernetesingress=true
+        ## the web UI on the host NIC port 8080 in **insecure** mode
+        - --api.dashboard
+        - --accesslog
+        - --api
+        - --api.insecure
+        - --log.level=INFO
+        - --metrics.prometheus
+        - --providers.kubernetesingress
+        - --providers.kubernetesingress.ingressclass=cluster-wide-ingress
+        - --entrypoints.http.Address=:80
         # you need to manually set this IP to the incoming public IP
         # that your ingress resources would use. Note it only affects
         # status and kubectl UI, and doesn't really do anything
         # It could even be left out https://github.com/containous/traefik/issues/6303
         - --providers.kubernetesingress.ingressendpoint.hostname=localhost
-        ## the web UI on the host NIC port 8080 in **insecure** mode
-        - --api.dashboard=true
-        - --api.insecure=true
-        - --log=true
-        - --log.level=INFO
-        - --accesslog=true
-
 ---
 kind: Service
 apiVersion: v1
@@ -91,8 +92,33 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - ingressroutes
+      - ingressroutetcps
+      - ingressrouteudps
+      - middlewares
+      - middlewaretcps
+      - tlsoptions
+      - tlsstores
+      - traefikservices
+      - serverstransports
     verbs:
       - get
       - list
@@ -110,3 +136,12 @@ subjects:
 - kind: ServiceAccount
   name: traefik-ingress-controller
   namespace: kube-system
+---
+kind: IngressClass
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cluster-wide-ingress
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: traefik.io/ingress-controller


### PR DESCRIPTION
- Add IngressClass to traefik controller to match nginx name
- Update to latest traefik 2.7

[Original Issue](https://www.udemy.com/instructor/communication/qa/17719032/detail?course=2428872)
