### PR TITLE
Fix typo "sever" to "server"

### DIFF
--- a/slides/k8smastery/ingress.md
+++ b/slides/k8smastery/ingress.md
@@ -120,7 +120,7 @@ name: ingress
 
   - the control loop watches over Ingress resources, and configures the LB accordingly
 
-  - these might be two separate processes (NGINX sever + NGINX Ingress controller)
+  - these might be two separate processes (NGINX server + NGINX Ingress controller)
 
   - or a single app that knows how to speak to Kubernetes API (Traefik)
 


### PR DESCRIPTION
I noticed this typo during the udemy course [Kubernetes Mastery: Hands-On Lessons From A Docker Captain](https://www.udemy.com/course/kubernetesmastery/)